### PR TITLE
Cleanup, test readiness

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c)2014, Tyler Holien
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Tyler Holien nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Network/Kafka/Protocol.hs
+++ b/Network/Kafka/Protocol.hs
@@ -307,8 +307,8 @@ instance Deserializable MessageSet where
     return $ MessageSet ms
       where getMembers :: Get [MessageSetMember]
             getMembers = do
-              empty <- isEmpty
-              if empty
+              wasEmpty <- isEmpty
+              if wasEmpty
               then return []
               else liftM2 (:) deserialize getMembers <|> (remaining >>= getBytes >> return [])
 

--- a/kafkah.cabal
+++ b/kafkah.cabal
@@ -5,59 +5,38 @@ name:                kafkah
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
 version:             0.1.0.0
-
 synopsis:            A Kafka client for Haskell.
-
--- description:
--- license:
+description:         Kafka client for Haskell
+license:             BSD3
 license-file:        LICENSE
 author:              Tyler Holien
 maintainer:          tyler.holien@gmail.com
-
--- A copyright notice.
--- copyright:
-
+copyright:           2014, Tyler Holien
 category:            Network
 build-type:          Simple
 stability:           alpha
-
 cabal-version:       >=1.10
 
 library
-  -- Modules exported by the library.
-  exposed-modules:
-    Network.Kafka,
-    Network.Kafka.Protocol
-
-  -- Modules included in this library but not exported.
-  -- other-modules:
-
-  -- LANGUAGE extensions used by modules in this package.
-  -- other-extensions:
-
-  -- Other library packages from which modules are imported.
-  build-depends:
-    base == 4.*,
-    cereal,
-    bytestring,
-    network,
-    digest
-
   default-language: Haskell2010
+  ghc-options:         -Wall
+  exposed-modules:     Network.Kafka,
+                       Network.Kafka.Protocol
+  build-depends:       base       >= 4.7   && <5,
+                       cereal     >=0.4      && <0.5,
+                       bytestring >=0.10     && <0.12,
+                       network    >=2.4      && <2.7,
+                       digest     >=0.0.1.0 && <0.0.2
 
 test-suite test
-  build-depends:
-    base == 4.*,
-    kafkah,
-    QuickCheck,
-    cereal,
-    bytestring
-
-  hs-source-dirs:
-    test
-
-  main-is:
-    Main.hs
-
-  type:
-    exitcode-stdio-1.0
+  default-language: Haskell2010
+  ghc-options:         -Wall -threaded
+  build-depends:       base,
+                       kafkah,
+                       QuickCheck,
+                       cereal,
+                       bytestring,
+                       hspec
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  type:                exitcode-stdio-1.0

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,12 @@
 module Main where
 
+-- import Network.Kafka
+import Test.Hspec
+
 main :: IO ()
-main = putStrLn "hello"
+main = hspec $ do
+
+  describe "can talk to local Kafka server" $ do
+    it "roundtrips producer -> consumer" $ do
+      putStrLn "hello"
+      1 `shouldBe` 0


### PR DESCRIPTION
Friendly PR to get the ball rolling.

Major initial concerns:

Inexhaustive pattern matches I commented on in produceStuff, `case resp of`.

Pervasive (Either String ...) - a sum type of all possible errors for the `Left` would be much nicer, bearing add'l stringly context if needed but a constructor to match on is important. I don't know what possible errors etc. would consist of but I can help out here if you'd like me to. May be related to inexhaustive pattern matches.

Let me know when you want to do the rename, I liked your suggestion.
