### PR TITLE
Compile with lts-5.3

### DIFF
--- a/milena.cabal
+++ b/milena.cabal
@@ -36,20 +36,20 @@ library
                        Network.Kafka.Consumer,
                        Network.Kafka.Protocol,
                        Network.Kafka.Producer
-  build-depends:       base          >=4.7      && <5,
-                       mtl           >=2.1      && <2.3,
-                       cereal        >=0.4      && <0.5,
-                       bytestring    >=0.10     && <0.11,
-                       network       >=2.4      && <2.7,
-                       digest        >=0.0.1.0  && <0.1,
-                       containers    >=0.5      && <0.6,
-                       random        >=1.0      && <1.2,
-                       transformers  >=0.3      && <0.5,
-                       lens          >=4.4      && <4.13,
-                       resource-pool >=0.2.3.2  && <0.3,
-                       lifted-base   >=0.2.3.6  && <0.3,
-                       murmur-hash   >=0.1.0.8  && <0.2,
-                       semigroups    >=0.16.2.2 && <0.17
+  build-depends:       base          >=4.7,
+                       mtl           >=2.1,
+                       cereal        >=0.4,
+                       bytestring    >=0.10,
+                       network       >=2.4,
+                       digest        >=0.0.1.0,
+                       containers    >=0.5,
+                       random        >=1.0,
+                       transformers  >=0.3,
+                       lens          >=4.4,
+                       resource-pool >=0.2.3.2,
+                       lifted-base   >=0.2.3.6,
+                       murmur-hash   >=0.1.0.8,
+                       semigroups    >=0.16.2.2
 
 test-suite test
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 flags: {}
 packages:
 - '.'
-extra-deps:
-resolver: lts-3.18
+extra-deps: []
+resolver: lts-5.3


### PR DESCRIPTION
Hi!

I've been investigating using Kafka with Haskell, and have been trying milena. I ran into some problems getting it to `stack build` with a recent `lts` version.

Changes:

* Removes the upper bounds (are these necessary?)
* Fixes `extra-deps` syntax in `stack.yaml`
* Updates the resolver